### PR TITLE
fix(install): make cmds easy to read

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -13,26 +13,31 @@ Credentials:
 How to generate Azure AKS `kubeconfig` file:
 
 ```sh
-$ az aks get-credentials --name MyManagedCluster --resource-group MyResourceGroup --file kubeconfig-azure
+az aks get-credentials --name MyManagedCluster \ 
+  --resource-group MyResourceGroup \ 
+  --file kubeconfig-azure
 ```
 
 How to generate AWS EKS `kubeconfig` file:
 
 ```sh
-$ aws eks update-kubeconfig --region us-west-1 --name backstack-hub --kubeconfig kubeconfig-aws
+aws eks update-kubeconfig --name backstack-hub \ 
+  --region us-west-1 \ 
+  --kubeconfig kubeconfig-aws
 ```
 
 How to generate Azure Credentials:
 
 ```sh
-$ az ad sp create-for-rbac --sdk-auth --role Owner --scopes /subscriptions/$YOURSUBSCRIPTIONID > azure.json
+az ad sp create-for-rbac --sdk-auth --role Owner \ 
+  --scopes /subscriptions/$YOURSUBSCRIPTIONID > azure.json
 ```
 
 How to pass AWS Credentials:
 **NOTE** Ensure you have stored your Key ID and Access Key in a file under the `default` heading (e.g.)
 
 ```sh
-$ cat ~/.aws/credentials
+cat ~/.aws/credentials
 [default]
 aws_access_key_id = YOURKEYHERE
 aws_secret_access_key = YOURSECRETKEYHERE
@@ -67,11 +72,14 @@ This bundle uses the following tools: docker, exec, helm3, Kubernetes.
 To install this bundle, run the following commands, passing `--param KEY=VALUE` for any parameters you want to customize:
 
 ```sh
-$ porter credentials generate back-stack-cloud-creds --reference ghcr.io/back-stack/showcase-bundle:latest
+porter credentials generate back-stack-cloud-creds \ 
+  --reference ghcr.io/back-stack/showcase-bundle:latest
 ```
 
 ```sh
-$ porter install --reference ghcr.io/back-stack/showcase-bundle:latest --credential-set back-stack-cloud-creds --param repository=https://github.com/USER/REPO
+porter install --reference ghcr.io/back-stack/showcase-bundle:latest \ 
+  --credential-set back-stack-cloud-creds \ 
+  --param repository=https://github.com/USER/REPO
 ```
 
 ### Installing Locally into KinD
@@ -82,19 +90,25 @@ The Porter bundle already includes KinD, so the only prerequisite is Docker/Dock
 2.  Generate the credentials config, leaving the `kubeconfig` empty (it will be ignored)
 
     ```sh
-    $ porter credentials generate back-stack-cloud-creds --reference ghcr.io/back-stack/showcase-bundle:latest
+    porter credentials generate back-stack-cloud-creds \ 
+      --reference ghcr.io/back-stack/showcase-bundle:latest
     ```
 
 3.  Install the bundle; the default `cluster-type` and `*-host` parameters are configured for local deployment, and you need to allow Porter to access your local docker daemon.
 
     ```sh
-    $ porter install back-stack --reference ghcr.io/back-stack/showcase-bundle:latest --credential-set back-stack-cloud-creds --param repository=https://github.com/USER/REPO --allow-docker-host-access
+    porter install back-stack \
+      --reference ghcr.io/back-stack/showcase-bundle:latest \
+      --credential-set back-stack-cloud-creds \
+      --param repository=https://github.com/USER/REPO \
+      --allow-docker-host-access
     ```
 
 To connect to the KinD cluster running the BACK stack, update your kubeconfig:
 
 ```sh
-$ porter installations output show kubeconfig-external -i back-stack > ~/.kube/config
+porter installations output show kubeconfig-external \ 
+  -i back-stack > ~/.kube/config
 ```
 
 ### Installing into EKS
@@ -106,26 +120,30 @@ $ porter installations output show kubeconfig-external -i back-stack > ~/.kube/c
 2.  Generate the credentials config, specifying the path to the `kubeconfig-aws` file
 
     ```sh
-    $ porter credentials generate back-stack-cloud-creds --reference ghcr.io/back-stack/showcase-bundle:latest
+    porter credentials generate back-stack-cloud-creds \ 
+      --reference ghcr.io/back-stack/showcase-bundle:latest
     ```
 
 3.  Install the bundle; set `cluster-type` to `eks` and specify DNS names that you want to use to access the BACK stack services. This can either be done using `--param` flags or by generating a parameter set
 
     ```sh
     # using parameter set
-    $ porter parameters generate back-stack-params --reference ghcr.io/back-stack/showcase-bundle:latest
+    porter parameters generate back-stack-params \ 
+      --reference ghcr.io/back-stack/showcase-bundle:latest
 
-    $ porter install back-stack --reference ghcr.io/back-stack/showcase-bundle:latest --credential-set back-stack-cloud-creds --parameter-set back-stack-params
+    porter install back-stack \ 
+      --reference ghcr.io/back-stack/showcase-bundle:latest \
+      --credential-set back-stack-cloud-creds \
+      --parameter-set back-stack-params
     ```
 
 4.  After installation, you need to ensure the DNS names specified for `argocd-host`, `backstage-host`, and `vault-host` all resolve to the ingress service created during installation. The endpoint for this can be found by checking the bundle outputs
 
     ```sh
-    $ porter installations output show ingress -i back-stack
+    porter installations output show ingress -i back-stack
     ```
 
     For this showcase, you can update `/etc/hosts`.
 
 [getporter]: https://porter.sh/
 [alb-controller]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
-


### PR DESCRIPTION
Keep line length under 80 chars to make it easy to see all the parameters used on commands in the docs. Right now, they require horizontal scrolling to see them. Also, remove the `$` at the line start to make the command usable on copy.